### PR TITLE
Add LIST benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased](https://github.com/hashicorp/vault-benchmark/tree/HEAD)
 
+- Support benchmarking KVv1, KVv2, and ACL LIST operations [\#5](https://github.com/openbao/benchmark-openbao/pull/5)
 - Add auth/secret engine mount benchmark [\#4](https://github.com/openbao/benchmark-openbao/pull/4)
 - Add `sys/policies/acl` benchmark [\#3](https://github.com/openbao/benchmark-openbao/pull/3)
 

--- a/benchmarktests/target_secret_kvv1.go
+++ b/benchmarktests/target_secret_kvv1.go
@@ -23,14 +23,19 @@ import (
 // Constants for test
 const (
 	KVV1ReadTestType    = "kvv1_read"
+	KVV1ListTestType    = "kvv1_list"
 	KVV1WriteTestType   = "kvv1_write"
 	KVV1ReadTestMethod  = "GET"
+	KVV1ListTestMethod  = "LIST"
 	KVV1WriteTestMethod = "POST"
 )
 
 func init() {
 	TestList[KVV1ReadTestType] = func() BenchmarkBuilder {
 		return &KVV1Test{action: "read"}
+	}
+	TestList[KVV1ListTestType] = func() BenchmarkBuilder {
+		return &KVV1Test{action: "list"}
 	}
 	TestList[KVV1WriteTestType] = func() BenchmarkBuilder {
 		return &KVV1Test{action: "write"}
@@ -79,6 +84,14 @@ func (k *KVV1Test) read(client *api.Client) vegeta.Target {
 	}
 }
 
+func (k *KVV1Test) list(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: KVV1ListTestMethod,
+		URL:    client.Address() + k.pathPrefix,
+		Header: k.header,
+	}
+}
+
 func (k *KVV1Test) write(client *api.Client) vegeta.Target {
 	secnum := int(1 + rand.Int31n(int32(k.numKVs)))
 	value := strings.Repeat("a", k.kvSize)
@@ -94,6 +107,8 @@ func (k *KVV1Test) Target(client *api.Client) vegeta.Target {
 	switch k.action {
 	case "write":
 		return k.write(client)
+	case "list":
+		return k.list(client)
 	default:
 		return k.read(client)
 	}
@@ -104,6 +119,8 @@ func (k *KVV1Test) GetTargetInfo() TargetInfo {
 	switch k.action {
 	case "write":
 		method = KVV1WriteTestMethod
+	case "list":
+		method = KVV1ListTestMethod
 	default:
 		method = KVV1ReadTestMethod
 	}

--- a/benchmarktests/target_sys_policies.go
+++ b/benchmarktests/target_sys_policies.go
@@ -24,8 +24,10 @@ import (
 
 const (
 	ACLPolicyReadType    = "acl_policy_read"
+	ACLPolicyListType    = "acl_policy_list"
 	ACLPolicyWriteType   = "acl_policy_write"
 	ACLPolicyReadMethod  = "GET"
+	ACLPolicyListMethod  = "LIST"
 	ACLPolicyWriteMethod = "POST"
 )
 
@@ -33,6 +35,9 @@ func init() {
 	// "Register" this test to the main test registry
 	TestList[ACLPolicyReadType] = func() BenchmarkBuilder {
 		return &ACLPolicyTest{action: "read"}
+	}
+	TestList[ACLPolicyListType] = func() BenchmarkBuilder {
+		return &ACLPolicyTest{action: "list"}
 	}
 	TestList[ACLPolicyWriteType] = func() BenchmarkBuilder {
 		return &ACLPolicyTest{action: "write"}
@@ -87,6 +92,14 @@ func (a *ACLPolicyTest) read(client *api.Client) vegeta.Target {
 	}
 }
 
+func (a *ACLPolicyTest) list(client *api.Client) vegeta.Target {
+	return vegeta.Target{
+		Method: ACLPolicyListMethod,
+		URL:    client.Address() + a.pathPrefix,
+		Header: a.header,
+	}
+}
+
 func (a *ACLPolicyTest) draftPolicy(paths int, pathLength int, capabilities []string) map[string]interface{} {
 	var policy string
 	for i := 0; i < paths; i++ {
@@ -128,6 +141,8 @@ func (a *ACLPolicyTest) Target(client *api.Client) vegeta.Target {
 	switch a.action {
 	case "write":
 		return a.write(client)
+	case "list":
+		return a.list(client)
 	default:
 		return a.read(client)
 	}
@@ -138,6 +153,8 @@ func (a *ACLPolicyTest) GetTargetInfo() TargetInfo {
 	switch a.action {
 	case "write":
 		method = ACLPolicyWriteMethod
+	case "list":
+		method = ACLPolicyListMethod
 	default:
 		method = ACLPolicyReadMethod
 	}

--- a/docs/examples/kv/kvv1-list.hcl
+++ b/docs/examples/kv/kvv1-list.hcl
@@ -1,0 +1,7 @@
+test "kvv1_list" "kvv1_list_test" {
+    weight = 100
+    config {
+        numkvs = 100
+        kvsize = 1000
+    }
+}

--- a/docs/examples/kv/kvv2-list.hcl
+++ b/docs/examples/kv/kvv2-list.hcl
@@ -1,0 +1,8 @@
+test "kvv2_list" "kvv2_list_test" {
+    weight = 100
+    config {
+        numkvs = 100
+        kvsize = 1000
+        detailed = false
+    }
+}

--- a/docs/examples/policies/acl-list.hcl
+++ b/docs/examples/policies/acl-list.hcl
@@ -1,0 +1,8 @@
+test "acl_policy_list" "acl_list_test" {
+    weight = 100
+    config {
+      policies = 100
+      paths = 25
+      path_length = 150
+    }
+}

--- a/docs/tests/secret-kv.md
+++ b/docs/tests/secret-kv.md
@@ -9,7 +9,8 @@ This benchmark tests the performance of KVV1 and/or KVV2.  It writes a set numbe
 - `numkvs` `(int: 1000)` - if any kvv1 or kvv2 requests are specified,
 then this many keys will be written during the setup phase.  The read operations
 will read from these keys, and the write operations overwrite them.
-- `kvsize` `(int: 1)`:  the size of the key and value to write.
+- `kvsize` `(int: 1)` - the size of the key and value to write.
+- `detailed` `(bool: false)` - enable detailed listing of secrets (KVv2 only).
 
 ## Example Configuration
 


### PR DESCRIPTION
This adds benchmarks for three LIST operations:

 - KVv2, optionally doing detailed list (fetching secrets as well)
 - ACL Policies
 - KVv1 lists

Most regular LIST operations (e.g., roles, ...) will behave like the KVv1 LIST. KVv2 has additional work it goes through, potentially decrypting keys, and ACL policies perform recursive LIST operations by default (and, may optionally return detailed information once https://github.com/openbao/openbao/pull/1224 is merged). 