### PR TITLE
allows disabling of http keep-alive

### DIFF
--- a/command/run.go
+++ b/command/run.go
@@ -17,10 +17,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/mitchellh/cli"
 	"github.com/openbao/benchmark-openbao/benchmarktests"
 	vbConfig "github.com/openbao/benchmark-openbao/config"
 	vaultapi "github.com/openbao/openbao/api/v2"
-	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -56,6 +56,7 @@ type RunCommand struct {
 	flagCleanup          bool
 	flagDebug            bool
 	flagDisableHTTP2     bool
+	flagDisableKeepAlive bool
 }
 
 func (r *RunCommand) Synopsis() string {
@@ -223,6 +224,13 @@ func (r *RunCommand) Flags() *FlagSets {
 		Usage:   "Force HTTP/1.1",
 	})
 
+	f.BoolVar(&BoolVar{
+		Name:    "disable_keep_alive",
+		Target:  &r.flagDisableKeepAlive,
+		Default: false,
+		Usage:   "Disable TCP connection reuse",
+	})
+
 	// Add any additional flags from tests
 	for _, vbTest := range benchmarktests.TestList {
 		vbTest().Flags(f.mainSet)
@@ -363,7 +371,7 @@ func (r *RunCommand) Run(args []string) int {
 		}
 
 		// Check if we're forcing HTTP/1.1. Used to make sure benchmark traffic
-		// is spread across nodes when Vault is behind a load balancer.
+		// is spread across nodes when OpenBao is behind a load balancer.
 		if conf.DisableHTTP2 {
 			benchmarkLogger.Warn("http2 disabled, using http/1.1")
 			transport := cfg.HttpClient.Transport.(*http.Transport)
@@ -371,6 +379,14 @@ func (r *RunCommand) Run(args []string) int {
 			transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
 			transport.ForceAttemptHTTP2 = false
 			cfg.HttpClient.Transport = transport
+		}
+
+		// Check if we're forcing a new connection per request. Used to make
+		// sure benchmark traffic is spread across nodes when OpenBao is behind
+		// a TCP load balancer.
+		if conf.DisableKeepAlive {
+			benchmarkLogger.Warn("tcp connection reuse disabled")
+			cfg.HttpClient.Transport.(*http.Transport).DisableKeepAlives = true
 		}
 
 		cfg.Address = addr
@@ -623,6 +639,13 @@ func (r *RunCommand) applyConfigOverrides(f *FlagSets, config *vbConfig.VaultBen
 		Default: false,
 	})
 	config.DisableHTTP2 = r.flagDisableHTTP2
+
+	r.setBoolFlag(f, config.DisableKeepAlive, &BoolVar{
+		Name:    "disable_keep_alive",
+		Target:  &r.flagDisableKeepAlive,
+		Default: false,
+	})
+	config.DisableKeepAlive = r.flagDisableKeepAlive
 }
 
 func (r *RunCommand) setBoolFlag(f *FlagSets, configVal bool, fVar *BoolVar) {

--- a/config/config.go
+++ b/config/config.go
@@ -24,26 +24,27 @@ const (
 )
 
 type VaultBenchmarkCoreConfig struct {
-	Remain         hcl.Body                          `hcl:",remain"`
-	VaultAddr      string                            `hcl:"vault_addr,optional"`
-	VaultToken     string                            `hcl:"vault_token,optional"`
-	VaultNamespace string                            `hcl:"vault_namespace,optional"`
-	Duration       string                            `hcl:"duration,optional"`
-	ReportMode     string                            `hcl:"report_mode,optional"`
-	AuditPath      string                            `hcl:"audit_path,optional"`
-	Annotate       string                            `hcl:"annotate,optional"`
-	ClusterJSON    string                            `hcl:"cluster_json,optional"`
-	CAPEMFile      string                            `hcl:"ca_pem_file,optional"`
-	PPROFInterval  string                            `hcl:"pprof_interval,optional"`
-	LogLevel       string                            `hcl:"log_level,optional"`
-	Tests          []*benchmarktests.BenchmarkTarget `hcl:"test,block"`
-	RPS            int                               `hcl:"rps,optional"`
-	Workers        int                               `hcl:"workers,optional"`
-	RandomMounts   bool                              `hcl:"random_mounts,optional"`
-	InputResults   bool                              `hcl:"input_results,optional"`
-	Cleanup        bool                              `hcl:"cleanup,optional"`
-	Debug          bool                              `hcl:"debug,optional"`
-	DisableHTTP2   bool                              `hcl:"disable_http2,optional"`
+	Remain           hcl.Body                          `hcl:",remain"`
+	VaultAddr        string                            `hcl:"vault_addr,optional"`
+	VaultToken       string                            `hcl:"vault_token,optional"`
+	VaultNamespace   string                            `hcl:"vault_namespace,optional"`
+	Duration         string                            `hcl:"duration,optional"`
+	ReportMode       string                            `hcl:"report_mode,optional"`
+	AuditPath        string                            `hcl:"audit_path,optional"`
+	Annotate         string                            `hcl:"annotate,optional"`
+	ClusterJSON      string                            `hcl:"cluster_json,optional"`
+	CAPEMFile        string                            `hcl:"ca_pem_file,optional"`
+	PPROFInterval    string                            `hcl:"pprof_interval,optional"`
+	LogLevel         string                            `hcl:"log_level,optional"`
+	Tests            []*benchmarktests.BenchmarkTarget `hcl:"test,block"`
+	RPS              int                               `hcl:"rps,optional"`
+	Workers          int                               `hcl:"workers,optional"`
+	RandomMounts     bool                              `hcl:"random_mounts,optional"`
+	InputResults     bool                              `hcl:"input_results,optional"`
+	Cleanup          bool                              `hcl:"cleanup,optional"`
+	Debug            bool                              `hcl:"debug,optional"`
+	DisableHTTP2     bool                              `hcl:"disable_http2,optional"`
+	DisableKeepAlive bool                              `hcl:"disable_keep_alive,optional"`
 }
 
 func NewVaultBenchmarkCoreConfig() *VaultBenchmarkCoreConfig {

--- a/docs/global-configs.md
+++ b/docs/global-configs.md
@@ -14,6 +14,8 @@
 
 `-disable_http2` `(bool: false)` - Disables HTTP/2 on the Vault client. This prevents benchmark from multiplexing connections to a single Vault server over HTTP/2.
 
+`-disable_keep_alive` `(bool: false)` - Disables HTTP Keep-Alive on the Vault client. This ensures a new TCP connection is made for every request, which is useful when benchmarking a Vault cluster behind a load balancer.
+
 `-duration` `(string: "10s")` - Test Duration.
 
 `-log_level` `(string: "INFO")` - Level to emit logs. Options are: INFO, WARN, DEBUG, TRACE. This can also be specified via the `VAULT_BENCHMARK_LOG_LEVEL` environment variable.


### PR DESCRIPTION
Add a new benchmark option (command-line flag and config file key) to disable HTTP Keep-Alive.
This ensures a new TCP connection is made for every request, which is useful when benchmarking a cluster behind a load balancer.